### PR TITLE
Adjust size of camera preview

### DIFF
--- a/DSFacialGestureDetectorExampleProject/DSFacialGestureDetectorExampleProject/ViewController.m
+++ b/DSFacialGestureDetectorExampleProject/DSFacialGestureDetectorExampleProject/ViewController.m
@@ -30,6 +30,9 @@ const float kTimeToDissmissDetectedGestureLabel = 2.6f;
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    CGRect screen = [[UIScreen mainScreen] bounds];
+    self.cameraPreview.bounds = screen;
+    
     self.facialGesturesDetector = [DSFacialGesturesDetector new];
     self.facialGesturesDetector.delegate = self;
     self.facialGesturesDetector.cameraPreviewView = self.cameraPreview;


### PR DESCRIPTION
Somehow auto layout for the camera preview View doesn't work. I need to add this so that the camera preview view is correctly resized to be fullscreen
